### PR TITLE
Fix deepfrag enviroment

### DIFF
--- a/deepfrag.py
+++ b/deepfrag.py
@@ -262,7 +262,7 @@ def get_fingerprints(args):
     print('[*] Loading fingerprint library ... ', end='')
     with h5py.File(str(get_fingerprints_path()), 'r') as f:
         f_smiles = f['smiles'][()]
-        f_fingerprints = f['fingerprints'][()].astype(np.float)
+        f_fingerprints = f['fingerprints'][()].astype(float)
     print('done.')
 
     return (f_smiles, f_fingerprints)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ gitdb==4.0.5
 GitPython==3.1.7
 gql==0.2.0
 graphql-core==1.1
-h5py==2.10.0
+h5py==3.10.0
 idna==2.10
 llvmlite==0.33.0
 numba==0.50.1
-numpy==1.19.1
+numpy==1.24.4
 nvidia-ml-py3==7.352.0
 pathtools==0.1.2
 Pillow==7.2.0
@@ -26,9 +26,6 @@ shortuuid==1.0.1
 six==1.15.0
 smmap==3.0.4
 subprocess32==3.5.4
-# pip install torch==1.6.0+cu101 torchvision==0.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
-#torch==1.6.0+cu101
-#torchvision==0.7.0+cu101
 tqdm==4.48.2
 urllib3==1.25.10
 wandb==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ gql==0.2.0
 graphql-core==1.1
 h5py==3.10.0
 idna==2.10
-llvmlite==0.33.0
-numba==0.50.1
+llvmlite==0.41.1
+numba==0.58.1
 numpy==1.24.4
 nvidia-ml-py3==7.352.0
 pathtools==0.1.2


### PR DESCRIPTION
I was trying to run deepfrag in a conda enviroment created with the following commands:
```
conda create -y -n DeepFrag-1.0.3 -c fastai -c conda-forge --file requirements.txt prody=1.11 rdkit
conda activate DeepFrag-1.0.3
pip install pyparsing==2.4.7 torch
```
I am reusing that enviroment for a couple more things, but I've checked those packages don't alter anything from the original enviroment, just add to it.

When trying to run this command:
```
python deepfrag.py  --receptor 4erf.pdb --ligand 4erf_0R3-1.pdb --out g1_4erf_0R3-1_1_C23.csv --full --cname C23 --num_grids 4 --top_k 10
``` 
I got this error:
```
/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/Bio/pairwise2.py:278: BiopythonDeprecationWarning: Bio.pairwise2 has been deprecated, and we intend to remove it in a future release of Biopython. As an alternative, please consider using Bio.Align.PairwiseAligner as a replacement, and contact the Biopython developers if you still need the Bio.pairwise2 module.
  warnings.warn(

DeepFrag 1.0.3

If you use DeepFrag in your research, please cite:

Green, H., Koes, D. R., & Durrant, J. D. (2021). DeepFrag: a deep convolutional
neural network for fragment-based lead optimization. Chemical Science.

[*] Running on device: gpu
[*] Loading model ... done.
[*] Loading fingerprint library ... done.
[*] Loading receptor: /data/relocated/ScipionUserData/projects/TestDeepFrag/Runs/000084_ProtChemDeepFrag/extra/4erf.pdb ... done.
[*] Loading ligand: /data/relocated/ScipionUserData/projects/TestDeepFrag/Runs/000084_ProtChemDeepFrag/extra/inputLigands/4erf_0R3-1.pdb ... done.
@> 32 atoms and 1 coordinate set(s) were parsed in 0.00s.
[*] Generating grids ... Traceback (most recent call last):
  File "/home/msalinas/Documents/scipion/software/em/DeepFrag-1.0.3/deepfrag/deepfrag.py", line 487, in <module>
    main()
  File "/home/msalinas/Documents/scipion/software/em/DeepFrag-1.0.3/deepfrag/deepfrag.py", line 483, in main
    run(args)
  File "/home/msalinas/Documents/scipion/software/em/DeepFrag-1.0.3/deepfrag/deepfrag.py", line 400, in run
    batch = generate_grids(args, model._args, rec_coords, rec_types,
  File "/home/msalinas/Documents/scipion/software/em/DeepFrag-1.0.3/deepfrag/deepfrag.py", line 294, in generate_grids
    batch = grid_util.get_raw_batch(
  File "/data/relocated/scipion/software/em/DeepFrag-1.0.3/deepfrag/leadopt/grid_util.py", line 594, in get_raw_batch
    mol_gridify(
  File "/data/relocated/scipion/software/em/DeepFrag-1.0.3/deepfrag/leadopt/grid_util.py", line 396, in mol_gridify
    gpu_gridify[(dw,dw,dw), (GPU_DIM,GPU_DIM,GPU_DIM)](
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/compiler.py", line 833, in __call__
    kernel = self.specialize(*args)
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/compiler.py", line 844, in specialize
    kernel = self.compile(argtypes)
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/compiler.py", line 863, in compile
    kernel.bind()
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/compiler.py", line 604, in bind
    self._func.get()
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/compiler.py", line 480, in get
    ptx = self.ptx.get()
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/compiler.py", line 450, in get
    ptx = nvvm.llvm_to_ptx(self.llvmir, opt=3, arch=arch,
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/cudadrv/nvvm.py", line 515, in llvm_to_ptx
    ptx = cu.compile(**opts)
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/cudadrv/nvvm.py", line 232, in compile
    self._try_error(err, 'Failed to compile\n')
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/cudadrv/nvvm.py", line 250, in _try_error
    self.driver.check_error(err, "%s\n%s" % (msg, self.get_log()))
  File "/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/cudadrv/nvvm.py", line 140, in check_error
    raise exc
numba.cuda.cudadrv.error.NvvmError: Failed to compile

<unnamed> (296, 18): parse expected binary operation in atomicrmw
NVVM_ERROR_COMPILATION
```
I tried running the code with `CUDA` versions:
- 10.1
- 10.2
- 11.7
- 12.2

And it consistently happened with every `CUDA` version

After speding some time investigation the causes of the error, I found out it's because of version incompatibility caused by `numpy`, although changing it's version also requires updating other packages.

So, this PR fixes the issue with the following changes:
- Updated `numpy` version
- Updated `numba`, `llvmlite`, and `h5py` versions accordingly
- Updated some deprecated `numpy` types usage to adapt the code to the new numpy
- Removed commented lines from `requirements.txt` (just for cleanlyness)

And, after that, I re-ran the command, and got:
```
/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/Bio/pairwise2.py:278: BiopythonDeprecationWarning: Bio.pairwise2 has been deprecated, and we intend to remove it in a future release of Biopython. As an alternative, please consider using Bio.Align.PairwiseAligner as a replacement, and contact the Biopython developers if you still need the Bio.pairwise2 module.
  warnings.warn(

DeepFrag 1.0.3

If you use DeepFrag in your research, please cite:

Green, H., Koes, D. R., & Durrant, J. D. (2021). DeepFrag: a deep convolutional
neural network for fragment-based lead optimization. Chemical Science.

[*] Running on device: gpu
[*] Loading model ... done.
[*] Loading fingerprint library ... done.
[*] Loading receptor: /data/relocated/ScipionUserData/projects/TestDeepFrag/Runs/000084_ProtChemDeepFrag/extra/4erf.pdb ... done.
[*] Loading ligand: /data/relocated/ScipionUserData/projects/TestDeepFrag/Runs/000084_ProtChemDeepFrag/extra/inputLigands/4erf_0R3-1.pdb ... done.
@> 32 atoms and 1 coordinate set(s) were parsed in 0.00s.
[*] Generating grids ... /home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/dispatcher.py:536: NumbaPerformanceWarning: Grid size 27 will likely result in GPU under-utilization due to low occupancy.
  warn(NumbaPerformanceWarning(msg))
/home/msalinas/Documents/miniconda/envs/DeepFrag-1.0.3/lib/python3.8/site-packages/numba/cuda/cudadrv/devicearray.py:886: NumbaPerformanceWarning: Host array used in CUDA kernel will incur copy overhead to/from device.
  warn(NumbaPerformanceWarning(msg))
done.
[*] Generated grids in 0.821 seconds.
/home/msalinas/Documents/scipion/software/em/DeepFrag-1.0.3/deepfrag/deepfrag.py:316: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  pred = model.predict(torch.tensor(batch).float()).cpu().numpy()
[*] Generated prediction in 0.14018797874450684 seconds.
[*] Wrote output to g1_4erf_0R3-1_1_C23.csv
```
It still has some warnings about code that could be better adapted/improved, but at least it now works.